### PR TITLE
Fix noise in the generated output

### DIFF
--- a/test_tryon.py
+++ b/test_tryon.py
@@ -44,6 +44,8 @@ gen_model = torch.nn.SyncBatchNorm.convert_sync_batchnorm(gen_model).to(device)
 if opt.isTrain and len(opt.gpu_ids):
     model_gen = torch.nn.parallel.DistributedDataParallel(gen_model, device_ids=[opt.local_rank])
 
+model_gen.eval()
+
 for data in tqdm(train_loader):
     real_image = data['image'].cuda()
     clothes = data['color'].cuda()


### PR DESCRIPTION
Setting `model_gen` to eval mode.
This ensures consistent behaviour across different batch sizes.

Solves the following issues: #36, #21, #7